### PR TITLE
[FIX] Correctly register request failures

### DIFF
--- a/OdooLocust/OdooLocust.py
+++ b/OdooLocust/OdooLocust.py
@@ -45,12 +45,12 @@ def send(self, service_name, method, *args):
         res = odoolib.json_rpc(self.url, "call", {"service": service_name, "method": method, "args": args})
     except Exception as e:
         total_time = int((time.time() - start_time) * 1000)
-        events.request_failure.fire(request_type="Odoo JsonRPC", name=call_name, response_time=total_time, exception=e)
+        events.request_failure.fire(request_type="Odoo JsonRPC", name=call_name, response_time=total_time, response_length=0, exception=e)
         raise e
     else:
         total_time = int((time.time() - start_time) * 1000)
         events.request_success.fire(request_type="Odoo JsonRPC", name=call_name, response_time=total_time, response_length=sys.getsizeof(res))
-    return res
+        return res
 
 
 odoolib.JsonRPCConnector.send = send

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 odoo-client-lib==1.1.2
-locustio
+locustio==0.14.6
 locust

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='OdooLocust',
       packages=["OdooLocust"],
       install_requires=[
           'odoo-client-lib',
-          'locustio',
+          'locustio==0.14.6',
           'locust',
       ],
       long_description="See the home page for any information: https://github.com/odoo/OdooLocust.",


### PR DESCRIPTION
Failed requests are not registered correctly. Therefore they do not appear
in the Locust dashboard.
The event is fired without the `response_length` argument, which makes it crash.
See https://docs.locust.io/en/0.14.6/api.html#locust.events.request_failure

`locustio` revision is fixed to ensure args compatibility.