### PR TITLE
[FIX] Deprecated request_success and request_failure event handlers

### DIFF
--- a/src/OdooLocust/OdooLocustUser.py
+++ b/src/OdooLocust/OdooLocustUser.py
@@ -45,11 +45,11 @@ def send(self, service_name, method, *args):
         res = odoolib.json_rpc(self.url, "call", {"service": service_name, "method": method, "args": args})
     except Exception as e:
         total_time = int((time.time() - start_time) * 1000)
-        events.request_failure.fire(request_type="OdooRPC", name=call_name, response_time=total_time, response_length=0, exception=e)
+        events.request.fire(request_type="OdooRPC", name=call_name, response_time=total_time, response_length=0, exception=e)
         raise e
     else:
         total_time = int((time.time() - start_time) * 1000)
-        events.request_success.fire(request_type="OdooRPC", name=call_name, response_time=total_time, response_length=sys.getsizeof(res))
+        events.request.fire(request_type="OdooRPC", name=call_name, response_time=total_time, response_length=sys.getsizeof(res))
         return res
 
 


### PR DESCRIPTION
Fix problem
AttributeError: 'Events' object has no attribute 'request_failure'
AttributeError: 'Events' object has no attribute 'request_success'

When using "OdooLocustUser" with a Locust version equal to or higher than 2.15.0 (https://docs.locust.io/en/stable/changelog.html#id2).